### PR TITLE
migrate hooks to object instead of array

### DIFF
--- a/examples/bare/src/pages/index.js
+++ b/examples/bare/src/pages/index.js
@@ -1,10 +1,10 @@
 import React from 'react'
-import {useCart, useCustomer} from 'gatsby-theme-shopify-core'
+import {useCustomer} from 'gatsby-theme-shopify-core'
 import {Link} from 'gatsby'
 import Customer from '../components/Customer'
 
 const IndexPage = () => {
-  const [{error, loading, data}, {login, logout, updatePassword}] = useCustomer()
+  const {error, loading, data, login, logout, updatePassword} = useCustomer()
 
   const [values, setValues] = React.useState({})
   const [password, setPassword] = React.useState('')

--- a/packages/gatsby-theme-shopify-core/src/context/CartProvider.js
+++ b/packages/gatsby-theme-shopify-core/src/context/CartProvider.js
@@ -161,7 +161,14 @@ const CartProvider = ({shopName, accessToken, endpoint, children}) => {
   }
 
   const value = React.useMemo(
-    () => [cart, {addToCart, updateCartLineItem, removeCartLineItem, emptyCart, createCheckout}],
+    () => ({
+      cart,
+      addToCart,
+      updateCartLineItem,
+      removeCartLineItem,
+      emptyCart,
+      createCheckout,
+    }),
     [cart],
   )
 

--- a/packages/gatsby-theme-shopify-core/src/context/CustomerProvider.js
+++ b/packages/gatsby-theme-shopify-core/src/context/CustomerProvider.js
@@ -171,153 +171,153 @@ const CustomerProvider = ({shopName, accessToken, endpoint, children}) => {
   const {error, loading, data, checkedCredentials} = state
 
   const value = React.useMemo(
-    () => [
-      {error, loading, data},
-      {
-        initializeCustomer: async () => {
-          // get access token from cookie or end effect immediately
-          const customerCookieAccessToken = Cookie.get(COOKIE_ACCESS_TOKEN)
-          if (!customerCookieAccessToken) {
-            dispatch({type: FETCH_SUCCESS, data: null})
-            return
-          }
-          // if already checked credentials end effect immediately
-          if (checkedCredentials) return
+    () => ({
+      error,
+      loading,
+      data,
+      initializeCustomer: async () => {
+        // get access token from cookie or end effect immediately
+        const customerCookieAccessToken = Cookie.get(COOKIE_ACCESS_TOKEN)
+        if (!customerCookieAccessToken) {
+          dispatch({type: FETCH_SUCCESS, data: null})
+          return
+        }
+        // if already checked credentials end effect immediately
+        if (checkedCredentials) return
 
-          dispatch({type: FETCH_INIT})
-          const renewAccessTokenData = await fetchShopifyStorefront({
+        dispatch({type: FETCH_INIT})
+        const renewAccessTokenData = await fetchShopifyStorefront({
+          shopName,
+          accessToken,
+          endpoint,
+          query: renewAccessTokenMutation,
+          variables: {customerAccessToken: customerCookieAccessToken},
+        })
+          .then(res => res.json())
+          .then(res => res)
+          .catch(err => {
+            dispatch({type: FETCH_ERROR, error: err})
+          })
+
+        // if fetch errored return
+        // TODO: probably do something here
+        if (!renewAccessTokenData) return
+
+        const {customerAccessToken, userErrors} = renewAccessTokenData.data.customerAccessTokenRenew
+
+        if (userErrors && userErrors.length > 0) {
+          // if token is no longer valid erase access token from provider and cookie
+          Cookie.remove(COOKIE_ACCESS_TOKEN)
+
+          dispatch({type: FETCH_ERROR, error: null})
+        } else {
+          // if token is valid store access token and add cookie
+          Cookie.set(COOKIE_ACCESS_TOKEN, customerAccessToken.accessToken, {
+            expires: new Date(customerAccessToken.expiresAt),
+          })
+          dispatch({
+            type: FETCH_SUCCESS,
+            data: customerAccessToken,
+          })
+        }
+      },
+      login: ({email, password} = {}) => {
+        return new Promise((resolve, reject) => {
+          if (!email || !password) {
+            reject(new Error(`email and password are required`))
+          }
+          fetchShopifyStorefront({
             shopName,
             accessToken,
             endpoint,
-            query: renewAccessTokenMutation,
-            variables: {customerAccessToken: customerCookieAccessToken},
+            query: loginMutation,
+            variables: {email, password},
           })
             .then(res => res.json())
-            .then(res => res)
-            .catch(err => {
-              dispatch({type: FETCH_ERROR, error: err})
-            })
+            .then(res => {
+              if (
+                res.errors ||
+                (res.data.customerAccessTokenCreate.customerUserErrors &&
+                  res.data.customerAccessTokenCreate.customerUserErrors.length > 0)
+              ) {
+                dispatch({
+                  type: LOGIN_ERROR,
+                  error: res.errors ? res.errors : res.data.customerAccessTokenCreate.customerUserErrors,
+                })
+                resolve(res)
+              } else {
+                Cookie.set(COOKIE_ACCESS_TOKEN, res.data.customerAccessTokenCreate.customerAccessToken.accessToken, {
+                  expires: new Date(res.data.customerAccessTokenCreate.customerAccessToken.expiresAt),
+                })
 
-          // if fetch errored return
-          // TODO: probably do something here
-          if (!renewAccessTokenData) return
-
-          const {customerAccessToken, userErrors} = renewAccessTokenData.data.customerAccessTokenRenew
-
-          if (userErrors && userErrors.length > 0) {
-            // if token is no longer valid erase access token from provider and cookie
-            Cookie.remove(COOKIE_ACCESS_TOKEN)
-
-            dispatch({type: FETCH_ERROR, error: null})
-          } else {
-            // if token is valid store access token and add cookie
-            Cookie.set(COOKIE_ACCESS_TOKEN, customerAccessToken.accessToken, {
-              expires: new Date(customerAccessToken.expiresAt),
+                dispatch({type: LOGIN_SUCCESS, data: res.data.customerAccessTokenCreate.customerAccessToken})
+                resolve(res)
+              }
             })
-            dispatch({
-              type: FETCH_SUCCESS,
-              data: customerAccessToken,
-            })
-          }
-        },
-        login: ({email, password} = {}) => {
-          return new Promise((resolve, reject) => {
-            if (!email || !password) {
-              reject(new Error(`email and password are required`))
-            }
-            fetchShopifyStorefront({
-              shopName,
-              accessToken,
-              endpoint,
-              query: loginMutation,
-              variables: {email, password},
-            })
-              .then(res => res.json())
-              .then(res => {
-                if (
-                  res.errors ||
-                  (res.data.customerAccessTokenCreate.customerUserErrors &&
-                    res.data.customerAccessTokenCreate.customerUserErrors.length > 0)
-                ) {
-                  dispatch({
-                    type: LOGIN_ERROR,
-                    error: res.errors ? res.errors : res.data.customerAccessTokenCreate.customerUserErrors,
-                  })
-                  resolve(res)
-                } else {
-                  Cookie.set(COOKIE_ACCESS_TOKEN, res.data.customerAccessTokenCreate.customerAccessToken.accessToken, {
-                    expires: new Date(res.data.customerAccessTokenCreate.customerAccessToken.expiresAt),
-                  })
-
-                  dispatch({type: LOGIN_SUCCESS, data: res.data.customerAccessTokenCreate.customerAccessToken})
-                  resolve(res)
-                }
-              })
-              .catch(err => reject(err))
-          })
-        },
-        logout: () => {
-          return new Promise((resolve, reject) => {
-            fetchShopifyStorefront({
-              shopName,
-              accessToken,
-              endpoint,
-              query: logoutMutation,
-              variables: {customerAccessToken: data.accessToken},
-            })
-              .then(res => res.json())
-              .then(res => {
-                if (
-                  res.errors ||
-                  (res.data.customerAccessTokenDelete.userErrors &&
-                    res.data.customerAccessTokenDelete.userErrors.length > 0)
-                ) {
-                  Cookie.remove(COOKIE_ACCESS_TOKEN)
-                  dispatch({
-                    type: LOGOUT_ERROR,
-                    error: res.errors ? res.errors : res.data.customerAccessTokenDelete.userErrors,
-                  })
-                  resolve(res)
-                } else {
-                  Cookie.remove(COOKIE_ACCESS_TOKEN)
-                  dispatch({type: LOGOUT_SUCCESS})
-                  resolve(res)
-                }
-              })
-              .catch(err => reject(err))
-          })
-        },
-        updatePassword: password => {
-          return new Promise((resolve, reject) => {
-            fetchShopifyStorefront({
-              shopName,
-              accessToken,
-              endpoint,
-              query: updatePasswordMutation,
-              variables: {customerAccessToken: data.accessToken, customer: {password}},
-            })
-              .then(res => res.json())
-              .then(res => {
-                if (
-                  res.errors ||
-                  (res.data.customerUpdate.customerUserErrors && res.data.customerUpdate.customerUserErrors.length > 0)
-                ) {
-                  dispatch({
-                    type: UPDATE_PASSWORD_ERROR,
-                    error: res.errors ? res.errors : res.data.customerUpdate.customerUserErrors,
-                  })
-                  resolve(res)
-                } else {
-                  Cookie.set(COOKIE_ACCESS_TOKEN, res.data.customerUpdate.customerAccessToken.accessToken)
-                  dispatch({type: UPDATE_PASSWORD_SUCCESS, data: res.data.customerUpdate.customerAccessToken})
-                  resolve(res)
-                }
-              })
-              .catch(err => reject(err))
-          })
-        },
+            .catch(err => reject(err))
+        })
       },
-    ],
+      logout: () => {
+        return new Promise((resolve, reject) => {
+          fetchShopifyStorefront({
+            shopName,
+            accessToken,
+            endpoint,
+            query: logoutMutation,
+            variables: {customerAccessToken: data.accessToken},
+          })
+            .then(res => res.json())
+            .then(res => {
+              if (
+                res.errors ||
+                (res.data.customerAccessTokenDelete.userErrors &&
+                  res.data.customerAccessTokenDelete.userErrors.length > 0)
+              ) {
+                Cookie.remove(COOKIE_ACCESS_TOKEN)
+                dispatch({
+                  type: LOGOUT_ERROR,
+                  error: res.errors ? res.errors : res.data.customerAccessTokenDelete.userErrors,
+                })
+                resolve(res)
+              } else {
+                Cookie.remove(COOKIE_ACCESS_TOKEN)
+                dispatch({type: LOGOUT_SUCCESS})
+                resolve(res)
+              }
+            })
+            .catch(err => reject(err))
+        })
+      },
+      updatePassword: password => {
+        return new Promise((resolve, reject) => {
+          fetchShopifyStorefront({
+            shopName,
+            accessToken,
+            endpoint,
+            query: updatePasswordMutation,
+            variables: {customerAccessToken: data.accessToken, customer: {password}},
+          })
+            .then(res => res.json())
+            .then(res => {
+              if (
+                res.errors ||
+                (res.data.customerUpdate.customerUserErrors && res.data.customerUpdate.customerUserErrors.length > 0)
+              ) {
+                dispatch({
+                  type: UPDATE_PASSWORD_ERROR,
+                  error: res.errors ? res.errors : res.data.customerUpdate.customerUserErrors,
+                })
+                resolve(res)
+              } else {
+                Cookie.set(COOKIE_ACCESS_TOKEN, res.data.customerUpdate.customerAccessToken.accessToken)
+                dispatch({type: UPDATE_PASSWORD_SUCCESS, data: res.data.customerUpdate.customerAccessToken})
+                resolve(res)
+              }
+            })
+            .catch(err => reject(err))
+        })
+      },
+    }),
     [state],
   )
 

--- a/packages/gatsby-theme-shopify-core/src/context/useCustomer.js
+++ b/packages/gatsby-theme-shopify-core/src/context/useCustomer.js
@@ -7,13 +7,13 @@ const useCustomer = () => {
   if (!context) {
     throw new Error(`useCustomer can only be used inside a CustomerProvider component`)
   }
-  const [customer, {initializeCustomer, ...remainingFunctions}] = context
+  const {customer, initializeCustomer, ...remainingFunctions} = context
 
   React.useEffect(() => {
     initializeCustomer()
   }, [])
 
-  return [customer, remainingFunctions]
+  return {customer, ...remainingFunctions}
 }
 
 export default useCustomer

--- a/packages/gatsby-theme-shopify/src/components/Account.js
+++ b/packages/gatsby-theme-shopify/src/components/Account.js
@@ -86,10 +86,9 @@ const customerQuery = `query customer($customerAccessToken: String!) {
 
 const Account = ({accessToken}) => {
   const {loading, error, data} = useStorefront({query: customerQuery, variables: {customerAccessToken: accessToken}})
-  // eslint-disable-next-line no-empty-pattern
-  const [{}, {logout}] = useCustomer()
-  // eslint-disable-next-line no-empty-pattern
-  const [{}, {emptyCart}] = useCart()
+  const {logout} = useCustomer()
+  const {emptyCart} = useCart()
+
   if (loading || !data) return null
   if (error) return <div>Error!</div>
   const {customer} = data
@@ -99,8 +98,9 @@ const Account = ({accessToken}) => {
     window.location.reload()
     return null
   }
+
   return (
-    <>
+    <div>
       <Styled.h1>Hello, {customer.displayName}</Styled.h1>
       <button
         type="button"
@@ -116,7 +116,7 @@ const Account = ({accessToken}) => {
       <Styled.p>{customer.lastName}</Styled.p>
       <Styled.p>{customer.email}</Styled.p>
       <Styled.p>{customer.phone}</Styled.p>
-    </>
+    </div>
   )
 }
 

--- a/packages/gatsby-theme-shopify/src/components/AuthenticatedRoute.js
+++ b/packages/gatsby-theme-shopify/src/components/AuthenticatedRoute.js
@@ -3,7 +3,7 @@ import {useCustomer} from 'gatsby-theme-shopify-core'
 import {navigate} from 'gatsby'
 
 const AuthenticatedRoute = ({component: Component, ...props}) => {
-  const [{loading, error, data}] = useCustomer()
+  const {loading, error, data} = useCustomer()
   if (loading) return null
   if (error) return <div>Error!</div>
   if (!data || !data.accessToken) {

--- a/packages/gatsby-theme-shopify/src/components/Header.js
+++ b/packages/gatsby-theme-shopify/src/components/Header.js
@@ -6,7 +6,7 @@ import {useCart} from 'gatsby-theme-shopify-core'
 
 const Header = () => {
   const [searchString, setSearchString] = React.useState('')
-  const [cart] = useCart()
+  const {cart} = useCart()
   const cartQuantity = cart.reduce((count, item) => count + item.quantity, 0)
 
   const handleSubmit = e => {

--- a/packages/gatsby-theme-shopify/src/components/Login.js
+++ b/packages/gatsby-theme-shopify/src/components/Login.js
@@ -5,7 +5,7 @@ import {useCustomer} from 'gatsby-theme-shopify-core'
 import {navigate} from 'gatsby'
 
 const Login = () => {
-  const [{data}, {login}] = useCustomer()
+  const {data, login} = useCustomer()
   if (data && data.accessToken) {
     navigate('/account')
   }

--- a/packages/gatsby-theme-shopify/src/components/ProductPage.js
+++ b/packages/gatsby-theme-shopify/src/components/ProductPage.js
@@ -7,7 +7,7 @@ import Layout from './Layout'
 
 const ProductPage = ({data}) => {
   // eslint-disable-next-line no-empty-pattern
-  const [{}, {addToCart}] = useCart()
+  const {addToCart} = useCart()
 
   const {shopifyProduct: product} = data
   const initialValues = Object.assign(...product.options.map(option => ({[option.name]: option.values[0]})), {

--- a/packages/gatsby-theme-shopify/src/pages/cart.js
+++ b/packages/gatsby-theme-shopify/src/pages/cart.js
@@ -5,7 +5,7 @@ import Layout from '../components/Layout'
 import Image from 'gatsby-image'
 
 const Cart = () => {
-  const [cart, {updateCartLineItem, removeCartLineItem, createCheckout}] = useCart()
+  const {cart, updateCartLineItem, removeCartLineItem, createCheckout} = useCart()
 
   const lineItems = cart.map(item => {
     const variant = item.product.variants.find(variant => variant.shopifyId === item.variantId)


### PR DESCRIPTION
`useCart`, `useCustomer`, and `useStorefront` now return an object with all data (`loading`, `error`, `data`) and functions (`login`, etc.) instead of an array.